### PR TITLE
Service creation script

### DIFF
--- a/raspberry-pi/install.sh
+++ b/raspberry-pi/install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+BASE_PATH="$(dirname "$(realpath "$0")")"
+
+SERVICE_NAME="word_clock.service"
+SERVICE_PATH="/etc/systemd/system/$SERVICE_NAME"
+SCRIPT_PATH="$BASE_PATH/src/wordclock/main.py"
+GIF_PATH="$BASE_PATH/heart-art.gif"
+WORKING_DIRECTORY="$BASE_PATH/src/wordclock"
+PYTHON_PATH="/usr/bin/python3"
+
+echo "Creating systemd service file at $SERVICE_PATH"
+sudo bash -c "cat > $SERVICE_PATH" <<EOF
+[Unit]
+Description=Word Clock Service
+After=multi-user.target
+
+[Service]
+ExecStart=$PYTHON_PATH $SCRIPT_PATH --pin D12 --brightness 0.5 --gif $GIF_PATH
+WorkingDirectory=$WORKING_DIRECTORY
+StandardOutput=inherit
+StandardError=inherit
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo "Enabling the $SERVICE_NAME to start on boot"
+sudo systemctl enable $SERVICE_NAME
+
+echo "Starting the $SERVICE_NAME service"
+sudo systemctl start $SERVICE_NAME
+
+echo "Checking the status of the $SERVICE_NAME service"
+sudo systemctl status $SERVICE_NAME
+
+echo "Installation complete!"


### PR DESCRIPTION
This pull request introduces a new installation script for setting up a systemd service for the Word Clock project on a Raspberry Pi. The script automates the creation, enabling, and starting of the service.

Key changes in the installation script:

* [`raspberry-pi/install.sh`](diffhunk://#diff-e072c24f7f31fae3dd522c3763fc025e606a880fd54b331b166cca82c39c12d1R1-R38): Added a new script to create a systemd service file for the Word Clock project, enable it to start on boot, and start the service. The script also checks the status of the service after starting it.