### PR TITLE
Initial ESP 32 clock

### DIFF
--- a/esp/wordclock/.gitignore
+++ b/esp/wordclock/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/esp/wordclock/.vscode/extensions.json
+++ b/esp/wordclock/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/esp/wordclock/include/README
+++ b/esp/wordclock/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/esp/wordclock/lib/README
+++ b/esp/wordclock/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/esp/wordclock/platformio.ini
+++ b/esp/wordclock/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
+lib_deps = 
+    adafruit/Adafruit NeoPixel

--- a/esp/wordclock/src/ClockDisplayHAL.cpp
+++ b/esp/wordclock/src/ClockDisplayHAL.cpp
@@ -1,0 +1,76 @@
+#include "ClockDisplayHAL.h"
+
+ClockDisplayHAL::WordMapping const ClockDisplayHAL::WORDS_TO_LEDS[] = {
+    {"HOUR_1", 20, 22}, {"HOUR_2", 45, 47}, {"HOUR_3", 15, 19}, {"HOUR_4", 67, 70}, {"HOUR_5", 40, 43}, {"HOUR_6", 12, 14}, {"HOUR_7", 55, 59}, {"HOUR_8", 29, 35}, {"HOUR_9", 36, 39}, {"HOUR_10", 9, 11}, {"HOUR_11", 24, 29}, {"HOUR_12", 48, 53}, {"OCLOCK", 0, 5}, {"PAST", 60, 63}, {"TO", 63, 64}, {"MINUTES", 77, 83}, {"THIRTY", 84, 89}, {"TWENTY", 102, 107}, {"TWENTYFIVE", 98, 107}, {"FIVE", 98, 101}, {"TEN", 91, 93}, {"FIFTEEN", 110, 116}, {"IS", 127, 128}, {"IT", 130, 131}};
+
+ClockDisplayHAL::ClockDisplayHAL(uint8_t pin, uint8_t brightness)
+    : pixels(NUM_LEDS, pin, NEO_GRB + NEO_KHZ800), brightness(brightness)
+{
+}
+
+void ClockDisplayHAL::setup()
+{
+    pixels.setBrightness(255);
+    pixels.begin();
+    pixels.show();
+}
+
+void ClockDisplayHAL::displayWord(const String &word, uint32_t color)
+{
+    for (auto mapping : WORDS_TO_LEDS)
+    {
+        if (word.equals(mapping.word))
+        {
+            for (uint8_t i = mapping.start; i <= mapping.end; ++i)
+            {
+                pixels.setPixelColor(i, color);
+            }
+            break;
+        }
+    }
+}
+
+uint16_t ClockDisplayHAL::cartesianToWordClockLEDStripIndex(uint8_t x, uint8_t y)
+{
+    uint16_t row_index;
+    uint16_t index;
+
+    if (y % 2 == 0)
+    {
+        row_index = NUM_LEDS - (y * WIDTH);
+        index = row_index - (x + 1);
+    }
+    else
+    {
+        row_index = NUM_LEDS - ((y + 1) * WIDTH);
+        index = row_index + x;
+    }
+
+    if (index < 0 || index >= NUM_LEDS)
+    {
+        // Add your error handling here
+        return 0;
+    }
+
+    return index;
+}
+
+void ClockDisplayHAL::setPixel(uint8_t x, uint8_t y, uint32_t color)
+{
+    uint16_t index = cartesianToWordClockLEDStripIndex(x, y);
+    pixels.setPixelColor(index, color);
+}
+
+void ClockDisplayHAL::clearPixels(bool show)
+{
+    pixels.clear();
+    if (show)
+    {
+        pixels.show();
+    }
+}
+
+void ClockDisplayHAL::show()
+{
+    pixels.show();
+}

--- a/esp/wordclock/src/ClockDisplayHAL.h
+++ b/esp/wordclock/src/ClockDisplayHAL.h
@@ -1,0 +1,34 @@
+#ifndef CLOCKDISPLAYHAL_H
+#define CLOCKDISPLAYHAL_H
+
+#include <Adafruit_NeoPixel.h>
+
+class ClockDisplayHAL
+{
+public:
+    static const uint16_t WIDTH = 12;
+    static const uint16_t HEIGHT = 11;
+    static const uint16_t NUM_LEDS = WIDTH * HEIGHT;
+
+    ClockDisplayHAL(uint8_t pin, uint8_t brightness);
+    void setup();
+    void displayWord(const String &word, uint32_t color);
+    void setPixel(uint8_t x, uint8_t y, uint32_t color);
+    void clearPixels(bool show = true);
+    void show();
+
+private:
+    Adafruit_NeoPixel pixels;
+    uint8_t brightness;
+
+    static const struct WordMapping
+    {
+        const char *word;
+        uint8_t start;
+        uint8_t end;
+    } WORDS_TO_LEDS[];
+
+    uint16_t cartesianToWordClockLEDStripIndex(uint8_t x, uint8_t y);
+};
+
+#endif

--- a/esp/wordclock/src/NetworkTimeHelper.cpp
+++ b/esp/wordclock/src/NetworkTimeHelper.cpp
@@ -1,0 +1,45 @@
+#include "NetworkTimeHelper.h"
+#include "SerialHelper.h"
+
+NetworkTimeHelper::NetworkTimeHelper(char* ssid, char* password, long gmtOffset_sec, int daylightOffset_sec)
+    : ssid(ssid), password(password), gmtOffset_sec(gmtOffset_sec), daylightOffset_sec(daylightOffset_sec), lastSyncTime(0) {}
+
+void NetworkTimeHelper::setup() {
+    WiFi.begin(ssid, password);
+    while (WiFi.status() != WL_CONNECTED) {
+        delay(500);
+        SERIAL_PRINT(".");
+    }
+    SERIAL_PRINTLN("WiFi connected");
+
+    syncTimeWithNTP();
+}
+
+void NetworkTimeHelper::update() {
+    unsigned long currentMillis = millis();
+    if (currentMillis - lastSyncTime >= syncInterval) {
+        syncTimeWithNTP();
+    }
+}
+
+void NetworkTimeHelper::syncTimeWithNTP() {
+    const char* ntpServer = "pool.ntp.org";
+    configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+
+    struct tm timeinfo;
+    if (!getLocalTime(&timeinfo)) {
+        SERIAL_PRINTLN("Failed to obtain time");
+    }
+    lastSyncTime = millis();
+}
+
+struct tm NetworkTimeHelper::getLocalTimeStruct() {
+    struct tm timeinfo;
+    if (getLocalTime(&timeinfo)) {
+        return timeinfo;
+    } else {
+        memset(&timeinfo, 0, sizeof(struct tm));
+        SERIAL_PRINTLN("Failed to obtain local time");
+        return timeinfo;
+    }
+}

--- a/esp/wordclock/src/NetworkTimeHelper.h
+++ b/esp/wordclock/src/NetworkTimeHelper.h
@@ -1,0 +1,24 @@
+#ifndef NETWORK_TIME_HELPER_H
+#define NETWORK_TIME_HELPER_H
+
+#include <WiFi.h>
+#include <time.h>
+
+class NetworkTimeHelper {
+public:
+    NetworkTimeHelper(char* ssid, char* password, long gmtOffset_sec, int daylightOffset_sec);
+    void setup();
+    void update();  
+    struct tm getLocalTimeStruct(); 
+private:
+    char* ssid;
+    char* password;
+    long gmtOffset_sec;  
+    int daylightOffset_sec;  
+    unsigned long lastSyncTime;
+    const unsigned long syncInterval = 86400000;  // 24 hours in milliseconds
+
+    void syncTimeWithNTP(); 
+};
+
+#endif

--- a/esp/wordclock/src/SerialHelper.cpp
+++ b/esp/wordclock/src/SerialHelper.cpp
@@ -1,0 +1,7 @@
+#include "SerialHelper.h"
+
+void initSerial() {
+#if USE_SERIAL
+    Serial.begin(9600);
+#endif
+}

--- a/esp/wordclock/src/SerialHelper.h
+++ b/esp/wordclock/src/SerialHelper.h
@@ -1,0 +1,17 @@
+#ifndef SERIAL_HELPER_H
+#define SERIAL_HELPER_H
+
+#include <Arduino.h>
+#include "config.h"
+
+#if USE_SERIAL
+    #define SERIAL_PRINT(x) Serial.print(x)
+    #define SERIAL_PRINTLN(x) Serial.println(x)
+#else
+    #define SERIAL_PRINT(x)
+    #define SERIAL_PRINTLN(x)
+#endif
+
+void initSerial();  // Function to initialize serial if needed
+
+#endif

--- a/esp/wordclock/src/WordClock.cpp
+++ b/esp/wordclock/src/WordClock.cpp
@@ -1,0 +1,85 @@
+#include "WordClock.h"
+
+const uint32_t COLORS[] = {
+    0xFF0000,  // Red
+    0x00FF00,  // Green
+    0x0000FF,  // Blue
+    0xFFFF00,  // Yellow
+    0xFF00FF,  // Magenta
+    0x00FFFF,  // Cyan
+    0xFFFFFF,  // White
+    0xA52A2A   // Brown
+};
+
+WordClock::WordClock(ClockDisplayHAL* clockDisplayHAL, NetworkTimeHelper* timeHelper) 
+    : clockDisplayHAL(clockDisplayHAL), timeHelper(timeHelper), lastHour(-1), allLastHighlightedWords("") {}
+
+void WordClock::highlightWord(const String &word, uint32_t color) {
+    clockDisplayHAL->displayWord(word, color);
+}
+
+String WordClock::getMinutesWord(int minute) {
+    if (minute < 5) return "OCLOCK";
+    else if (minute < 10) return "FIVE";
+    else if (minute < 15) return "TEN";
+    else if (minute < 20) return "FIFTEEN";
+    else if (minute < 25) return "TWENTY";
+    else if (minute < 30) return "TWENTYFIVE";
+    else if (minute < 35) return "THIRTY";
+    else if (minute < 40) return "TWENTYFIVE";
+    else if (minute < 45) return "TWENTY";
+    else if (minute < 50) return "FIFTEEN";
+    else if (minute < 55) return "TEN";
+    else return "FIVE";
+}
+
+uint32_t WordClock::getRandomColor() {
+    int index = random(0, sizeof(COLORS) / sizeof(COLORS[0]));
+    return COLORS[index];
+}
+
+void WordClock::displayTime() {
+    struct tm currentTime = timeHelper->getLocalTimeStruct();
+
+    int hour = currentTime.tm_hour % 12;
+    if (hour == 0) hour = 12;  // Handle 12-hour format
+
+    int minute = currentTime.tm_min;
+    
+    clockDisplayHAL->clearPixels(false);  // Clear the display but don't show yet
+
+    if (hour != lastHour && minute == 0) {
+        lastHour = hour;
+        clockDisplayHAL->clearPixels(false);
+    }
+
+    highlightWord("IT", getRandomColor());
+    highlightWord("IS", getRandomColor());
+    String allHighlightedWords = "ITIS";
+
+    if (minute < 5) {
+        highlightWord("OCLOCK", getRandomColor());
+        allHighlightedWords += "OCLOCK";
+    } else if (minute < 35) {
+        highlightWord("PAST", getRandomColor());
+        highlightWord("MINUTES", getRandomColor());
+        allHighlightedWords += "PASTMINUTES";
+    } else {
+        highlightWord("TO", getRandomColor());
+        highlightWord("MINUTES", getRandomColor());
+        allHighlightedWords += "TOMINUTES";
+        hour = (hour + 1) % 12;
+        if (hour == 0) hour = 12;
+    }
+
+    String hourWord = "HOUR_" + String(hour);
+    highlightWord(getMinutesWord(minute), getRandomColor());
+    allHighlightedWords += getMinutesWord(minute);
+    highlightWord(hourWord, getRandomColor());
+    allHighlightedWords += hourWord;
+
+    if (allLastHighlightedWords != allHighlightedWords) {
+        clockDisplayHAL->show();  // Only show if there's a change
+        allLastHighlightedWords = allHighlightedWords;
+    }
+}

--- a/esp/wordclock/src/WordClock.h
+++ b/esp/wordclock/src/WordClock.h
@@ -1,0 +1,24 @@
+#ifndef WORDCLOCK_H
+#define WORDCLOCK_H
+
+#include <Arduino.h>
+#include "ClockDisplayHAL.h"
+#include "NetworkTimeHelper.h"
+
+class WordClock {
+public:
+    WordClock(ClockDisplayHAL* clockDisplayHAL, NetworkTimeHelper* timeHelper);
+    void displayTime();  // This will handle the main time display logic
+
+private:
+    int lastHour;
+    String allLastHighlightedWords;
+    ClockDisplayHAL* clockDisplayHAL;
+    NetworkTimeHelper* timeHelper;
+
+    void highlightWord(const String &word, uint32_t color = 0xFFFFFF);
+    String getMinutesWord(int minute);
+    uint32_t getRandomColor();
+};
+
+#endif

--- a/esp/wordclock/src/main.cpp
+++ b/esp/wordclock/src/main.cpp
@@ -1,0 +1,25 @@
+#include <Arduino.h>
+#include <Adafruit_NeoPixel.h>
+#include "ClockDisplayHAL.h"
+#include "NetworkTimeHelper.h"
+#include "SerialHelper.h"
+#include "config.h"
+#include "WordClock.h"
+
+NetworkTimeHelper timeHelper(WIFI_SSID, WIFI_PASSWORD, GMT_OFFSET_SEC, DAYLIGHT_OFFSET_SEC);
+ClockDisplayHAL clockDisplayHAL(LED_PIN, 255);
+WordClock wordClock(&clockDisplayHAL, &timeHelper);
+
+void setup()
+{
+    initSerial();
+    timeHelper.setup();
+    clockDisplayHAL.setup();
+}
+
+void loop()
+{
+    timeHelper.update();
+    wordClock.displayTime();
+    delay(1000);
+}

--- a/esp/wordclock/test/README
+++ b/esp/wordclock/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
This pull request includes several changes to the `esp/wordclock` project, focusing on adding new functionalities, improving configuration, and enhancing documentation. The most important changes include the addition of new classes for handling display and network time, configuration updates, and documentation improvements.

### New Functionalities

* **Clock Display Handling**:
  - Added `ClockDisplayHAL` class to manage the LED display, including methods to set up, display words, and manage individual pixels. (`esp/wordclock/src/ClockDisplayHAL.cpp`, `esp/wordclock/src/ClockDisplayHAL.h`) [[1]](diffhunk://#diff-33cdb542120ef7a54a01e7439643be8736571d87a27ec165fb4ece8659922cffR1-R76) [[2]](diffhunk://#diff-882df001d2b8c16f593936b6ab45217617487c47280799e9af5d7972159c267bR1-R34)
  - Added `WordClock` class to handle the main logic for displaying time using words. (`esp/wordclock/src/WordClock.cpp`, `esp/wordclock/src/WordClock.h`) [[1]](diffhunk://#diff-9b693a88e6c54642ba4248009eaec7b7caf2b85507b16a8d5855b3974e596ba5R1-R85) [[2]](diffhunk://#diff-7a9362798ee3dec0fa8d25ede0ad406239c0782c647e6ff01972aab1645c87cfR1-R24)

* **Network Time Synchronization**:
  - Added `NetworkTimeHelper` class to manage Wi-Fi connections and synchronize time with NTP servers. (`esp/wordclock/src/NetworkTimeHelper.cpp`, `esp/wordclock/src/NetworkTimeHelper.h`) [[1]](diffhunk://#diff-6cff015bd3f8ba5bed83cea2af62b150ed7b15027bfad4ee7f51c51b438970ddR1-R45) [[2]](diffhunk://#diff-54a61307954f0263d0996ebea2e836dadc6594f734b2ca089abececc0fcd19cdR1-R24)

### Configuration Updates

* **Project Configuration**:
  - Added `platformio.ini` file to define project-specific configurations, such as the board type and library dependencies. (`esp/wordclock/platformio.ini`)
  - Added `config.h` file to store configuration constants like Wi-Fi credentials and timezone information. (`esp/wordclock/src/config.h`)

### Documentation Enhancements

* **Documentation for Directories**:
  - Added README files to `include`, `lib`, and `test` directories to explain their intended use and provide examples. (`esp/wordclock/include/README`, `esp/wordclock/lib/README`, `esp/wordclock/test/README`) [[1]](diffhunk://#diff-7459829e5ecee6b7a8c22850f35c3918e881de5f3cc8cd6024d68761ef881ed3R1-R39) [[2]](diffhunk://#diff-caf0c1d76c26244ef7ad75db9aa94a5f2ec74906b7067728980a49a4208e9e41R1-R46) [[3]](diffhunk://#diff-1b342ed4f57cf4dfaa88270e0a8887a5caeea0ff2a6a1c274b9e850ec0012684R1-R11)

### Miscellaneous

* **.gitignore and VSCode Settings**:
  - Updated `.gitignore` to exclude build and VSCode-specific files. (`esp/wordclock/.gitignore`)
  - Added `extensions.json` to recommend VSCode extensions for the project. (`esp/wordclock/.vscode/extensions.json`)

### Main Application

* **Main Application Logic**:
  - Updated `main.cpp` to initialize and run the core components, including serial communication, network time synchronization, and word clock display. (`esp/wordclock/src/main.cpp`)